### PR TITLE
Update TinyCoreLinuxWithQemuGuestAgent.pkr.hcl

### DIFF
--- a/TinyCoreLinuxWithQemuGuestAgent.pkr.hcl
+++ b/TinyCoreLinuxWithQemuGuestAgent.pkr.hcl
@@ -15,7 +15,7 @@ source "qemu" "qemu" {
     ssh_password = "installation"
     shutdown_command = "sudo poweroff"
     boot_command = [
-        "<enter><wait15>",
+        "<enter><wait40>",
         "tce-load -wi openssh<enter>",
         "sudo cp /usr/local/etc/ssh/sshd_config.orig /usr/local/etc/ssh/sshd_config<enter>",
         "sudo /usr/local/etc/init.d/openssh start<enter>",


### PR DESCRIPTION
Increase boot time timeout to 40 seconds, as 15 seconds may not be enough in non-accelerated env.